### PR TITLE
Fix HOST_ARCH for Debian distributions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -183,7 +183,7 @@ function sanity_check {
 
 	# CURL
 	test -x "$(which curl)" || goodbye "curl is missing from your system. Please install it and try again." 10
-	arch=$(uname -i)
+	arch=$(uname -m)
 
 	# SYSTEM ARCHITECTURE
 	case $arch in


### PR DESCRIPTION
uname -i is non-portable and on Debian distros returns "unknown" (kernel version 5.18.0-4-amd64) which breaks extraction of the binary's download URL.