### PR TITLE
fix: ci tag check from install job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         if: success()
         id: git_last_tag
         run: |
-          echo '::set-output name=previous_tag::$(git tag --sort=version:refname | grep -v "$(git describe --tags)" | grep -E "v[0-9]+.[0-9]+.[0-9]+$"| tail -n1)'
+          echo '::set-output name=previous_tag::$(git tag --sort=version:refname | grep -E "v[0-9]+.[0-9]+.[0-9]+$" | tail -n1)'
 
       - name: Run Agent Install Tests
         if: success()


### PR DESCRIPTION
the git describe --tags should not
be used here as a filter because
it excludes the current tag.

We use the above filter in the release
job, where it is needed since we want to
get the previous tag in order to calculate
the commit changelog