### PR TITLE
Fix docker log error handling

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -128,7 +128,8 @@ func (d *Flow) DiscoverContainer() (*types.Container, error) {
 	errs := &utils.AutoConfigError{}
 	containers, err := utils.GetRunningContainers()
 	if err != nil {
-		log.Warnw("cannot access docker daemon, will attempt to auto-configure anyway", zap.Error(err))
+		log.Warnw("cannot access docker daemon, discovery failed", zap.Error(err))
+		errs.Append(err)
 	} else {
 		container, err := utils.MatchContainer(containers, d.config.ContainerRegex)
 		if err != nil {

--- a/internal/pkg/discover/mock.go
+++ b/internal/pkg/discover/mock.go
@@ -78,7 +78,7 @@ func (m *MockBlockchain) NodeVersion() string {
 
 // DiscoverContainer returns the container discovered or an error if any occurs
 func (m *MockBlockchain) DiscoverContainer() (*types.Container, error) {
-	return &types.Container{}, nil
+	return &types.Container{Names: []string{"/flow-private-network_consensus_3_1"}}, nil
 }
 
 // Network ...

--- a/internal/pkg/watch/docker_container.go
+++ b/internal/pkg/watch/docker_container.go
@@ -126,10 +126,10 @@ func (w *ContainerWatch) repairEventStream(ctx context.Context) (
 		return nil, nil, err
 	}
 
-	if container == nil {
+	if container == nil || len(container.Names) == 0 {
 		global.AgentRuntimeState.SetDiscoveryState(global.NodeDiscoveryError)
 
-		return nil, nil, fmt.Errorf("got nil container without an error")
+		return nil, nil, fmt.Errorf("got nil container or container with empty names, without an error")
 	}
 
 	filter := filters.NewArgs()
@@ -138,7 +138,7 @@ func (w *ContainerWatch) repairEventStream(ctx context.Context) (
 	filter.Add("status", "stop")
 	filter.Add("status", "kill")
 	filter.Add("status", "die")
-	filter.Add("container", container.ID)
+	filter.Add("container", container.Names[0])
 	options := dt.EventsOptions{Filters: filter}
 
 	msgchan, errchan, err := utils.DockerEvents(ctx, options)

--- a/internal/pkg/watch/docker_container.go
+++ b/internal/pkg/watch/docker_container.go
@@ -15,6 +15,7 @@ package watch
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"agent/api/v1/model"
@@ -123,6 +124,12 @@ func (w *ContainerWatch) repairEventStream(ctx context.Context) (
 		global.AgentRuntimeState.SetDiscoveryState(global.NodeDiscoveryError)
 
 		return nil, nil, err
+	}
+
+	if container == nil {
+		global.AgentRuntimeState.SetDiscoveryState(global.NodeDiscoveryError)
+
+		return nil, nil, fmt.Errorf("got nil container without an error")
 	}
 
 	filter := filters.NewArgs()

--- a/internal/pkg/watch/docker_logs.go
+++ b/internal/pkg/watch/docker_logs.go
@@ -193,8 +193,6 @@ func (w *DockerLogWatch) StartUnsafe() {
 			default:
 			}
 
-			if err != nil {
-			}
 			n, err := rc.Read(hdr)
 			if err != nil {
 				lastErr = err

--- a/internal/pkg/watch/docker_logs.go
+++ b/internal/pkg/watch/docker_logs.go
@@ -193,37 +193,42 @@ func (w *DockerLogWatch) StartUnsafe() {
 			default:
 			}
 
+			if err != nil {
+			}
 			n, err := rc.Read(hdr)
 			if err != nil {
 				lastErr = err
-				if err == io.EOF {
-					w.Log.Error("EOF reached (hdr), resetting stream")
-					time.Sleep(5 * time.Second)
-					ctx := map[string]interface{}{
-						model.NodeIDKey:      global.BlockchainNode.NodeID(),
-						model.NodeTypeKey:    global.BlockchainNode.NodeType(),
-						model.NodeVersionKey: global.BlockchainNode.NodeVersion(),
-					}
+				if err != io.EOF && err != io.ErrUnexpectedEOF {
+					w.Log.Errorw("error reading header", zap.Error(err), "reader", rc)
 
-					ev, err := model.NewWithCtx(ctx, model.AgentNodeLogMissingName, timesync.Now())
-					if err != nil {
-						w.Log.Errorw("error creating event: ", zap.Error(err))
-					} else {
-						if err := emit.Ev(w, ev); err != nil {
-							w.Log.Errorw("error emitting event: ", zap.Error(err))
-						}
-					}
+					continue
+				}
 
-					cancel()
-					if err := rc.Close(); err != nil {
-						w.Log.Errorw("error closing docker logs stream", zap.Error(err))
-					}
+				w.Log.Error("EOF error while reading header, will try to recover in 5s")
+				time.Sleep(5 * time.Second)
 
-					if stopped := newEventStream(); stopped {
-						return
-					}
+				ctx := map[string]interface{}{
+					model.NodeIDKey:      global.BlockchainNode.NodeID(),
+					model.NodeTypeKey:    global.BlockchainNode.NodeType(),
+					model.NodeVersionKey: global.BlockchainNode.NodeVersion(),
+				}
+
+				ev, err := model.NewWithCtx(ctx, model.AgentNodeLogMissingName, timesync.Now())
+				if err != nil {
+					w.Log.Errorw("error creating event: ", zap.Error(err))
 				} else {
-					w.Log.Errorw("error reading header", zap.Error(err))
+					if err := emit.Ev(w, ev); err != nil {
+						w.Log.Errorw("error emitting event: ", zap.Error(err))
+					}
+				}
+
+				cancel()
+				if err := rc.Close(); err != nil {
+					w.Log.Errorw("error closing docker logs stream", zap.Error(err))
+				}
+
+				if stopped := newEventStream(); stopped {
+					return
 				}
 
 				continue
@@ -249,33 +254,35 @@ func (w *DockerLogWatch) StartUnsafe() {
 			n, err = rc.Read(buf)
 			if err != nil {
 				lastErr = err
-				if err == io.EOF {
-					w.Log.Error("EOF reached (data), resetting stream")
-					ctx := map[string]interface{}{
-						model.NodeIDKey:      global.BlockchainNode.NodeID(),
-						model.NodeTypeKey:    global.BlockchainNode.NodeType(),
-						model.NodeVersionKey: global.BlockchainNode.NodeVersion(),
-					}
+				if err != io.EOF && err != io.ErrUnexpectedEOF {
+					w.Log.Errorw("error reading data", zap.Error(err), "reader", rc)
 
-					ev, err := model.NewWithCtx(ctx, model.AgentNodeLogMissingName, timesync.Now())
-					if err != nil {
-						w.Log.Errorw("error creating event: ", zap.Error(err))
-					} else {
-						if err := emit.Ev(w, ev); err != nil {
-							w.Log.Errorw("error emitting event: ", zap.Error(err))
-						}
-					}
+					continue
+				}
 
-					cancel()
-					if err := rc.Close(); err != nil {
-						w.Log.Errorw("error closing docker logs stream: ", zap.Error(err))
-					}
+				w.Log.Error("EOF error while reading log data, will try to recover log streaming immediately")
+				ctx := map[string]interface{}{
+					model.NodeIDKey:      global.BlockchainNode.NodeID(),
+					model.NodeTypeKey:    global.BlockchainNode.NodeType(),
+					model.NodeVersionKey: global.BlockchainNode.NodeVersion(),
+				}
 
-					if stopped := newEventStream(); stopped {
-						return
-					}
+				ev, err := model.NewWithCtx(ctx, model.AgentNodeLogMissingName, timesync.Now())
+				if err != nil {
+					w.Log.Errorw("error creating event: ", zap.Error(err))
 				} else {
-					w.Log.Errorw("error reading data", zap.Error(err))
+					if err := emit.Ev(w, ev); err != nil {
+						w.Log.Errorw("error emitting event: ", zap.Error(err))
+					}
+				}
+
+				cancel()
+				if err := rc.Close(); err != nil {
+					w.Log.Errorw("error closing docker logs stream: ", zap.Error(err))
+				}
+
+				if stopped := newEventStream(); stopped {
+					return
 				}
 
 				continue


### PR DESCRIPTION
Fixes an issue where the agent would enter an infinite loop from which is unable to recover when `err == io.ErrUnexpectedEOF` while streaming docker logs.