### PR TITLE
Caddyfile configuration to allow only agent node discovery operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ systemctl restart caddy
 ```
 5. Use the following one-liner to install the Metrika Agent bypassing adding `metrikad` user to `docker` group and configuring `DOCKER_HOST` environment variable.
 ```bash
-DOCKER_HOST=tcp://127.0.0.1:2379 DOCKER_API_VERSION=1.24 MA_BLOCKCHAIN={protocol} MA_API_KEY={api_key} bash -c "$(curl -sL https://raw.githubusercontent.com/Metrika-Inc/agent/main/install.sh) --no-docker-grp"
+DOCKER_HOST=tcp://127.0.0.1:2379 DOCKER_API_VERSION=1.41 MA_BLOCKCHAIN={protocol} MA_API_KEY={api_key} bash -c "$(curl -sL https://raw.githubusercontent.com/Metrika-Inc/agent/main/install.sh) --no-docker-grp"
 ```
 6. Test the proxy forwards requests to the Docker daemon for `metrikad` user:
 ```bash
@@ -70,7 +70,7 @@ This covers a subset of configuration options that are most likely to be changed
 * `buffer.max_heap_alloc` - maximum allowed allocations in heap (in bytes). Acts as a limit to prevent unlimited buffering. Default: `50MB`.
 * `runtime.logging.outputs` - where Metrika outputs logs, can specify multiple sources. Default: `stdout` (journalctl). **Warning**: Metrika Agent does not take care of rotating the logs.
 * `runtime.logging.level` - verbosity of the logs. Default - `warning`. Recommended to increase to `debug` when troubleshooting.
-* `runtime.use_exporters` **(work in progress)* - enable other exporters. More on this in [Exporter API](#exporter-api). Default: `false`.
+* `runtime.use_exporters` **(work in progress)** - enable other exporters. More on this in [Exporter API](#exporter-api). Default: `false`.
 * `runtime.watchers` - list of enabled watchers (collectors). More on this in [Watchers](#watchers).
 ## Agent internals
 ### Watchers

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The script serves as installer by default, but can also be used with flags `--up
 The agent can run as a standalone binary, as long as configuration files are set up correctly.
 
 ### Using a Docker reverse proxy
-If you'd like to avoid adding `metrikad` user to the `docker` group you can alternatively use a reverse proxy to filter traffic before it reaches the non-networked Docker socket and avoid having the agent process speaking directly to it. With this setup, the reverse proxy must be still run by a user that belongs to the `docker` group, so that it can proxy requests to the UNIX socket.
+To avoid adding the `metrikad` user to the `docker` group, you can use a reverse proxy. The reverse proxy filters traffic before it reaches the non-networked Docker socket, limiting the docker API calls the agent can make. Note that the reverse proxy still needs to be executed by a user that belongs to the docker group, so it can proxy requests to the UNIX socket.
 
 The following process assumes a Debian based host and describes the steps required to install the agent, using [Caddy](https://caddyserver.com/) as a reverse proxy to the Docker daemon. The `Caddyfile` used is the least required configuration needed by the agent to perform its container discovery operations.
 
@@ -33,14 +33,11 @@ The following process assumes a Debian based host and describes the steps requir
 ```bash
 usermod --append --groups docker caddy
 ```
-
-3. Copy the recommended [Caddyfile](https://raw.githubusercontent.com/Metrika-Inc/agent/main/caddy/Caddyfile) to Caddy's default configuration location `/etc/caddy/Caddyfile`:
+3. Download the recommended [Caddyfile](https://raw.githubusercontent.com/Metrika-Inc/agent/main/caddy/Caddyfile) and replace `<ma_container>` with the name of the blockchain node container. Finally move `Caddyfile` to `/etc/caddy/Caddyfile`:
 ```bash
-curl -sL https://raw.githubusercontent.com/Metrika-Inc/agent/main/caddy/Caddyfile | tee /etc/caddy/Caddyfile
-caddy reload --config /etc/caddy/Caddyfile
+curl -sL https://raw.githubusercontent.com/Metrika-Inc/agent/main/caddy/Caddyfile | sed 's/<ma_container>/example-name/g' | tee /etc/caddy/Caddyfile
 ```
-
-By default, the agent will configure its Docker client to send HTTP header `X-Ma-User` on every request it sends to the Docker Daemon with the username resolved by the agent process. Using this `Caddyfile`, the proxy filters requests to the Daemon based on username and the API paths needed by the agents.
+This `Caddyfile` filters requests to the Daemon based on the API paths needed by the agents.
 
 4. Restart Caddy:
 ```bash

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -3,19 +3,19 @@ http://127.0.0.1:2379 {
 	# Required by Metrika Agent for container discovery
 	@containersurl {
 		method GET
-		path /v1.24/containers/json
+		path /v1.41/containers/json
 	}
 
 	# Required by Metrika Agent to stream container logs
 	@containerlogsurl {
 		method GET
-		path /v1.24/containers/<ma_container>/logs
+		path /v1.41/containers/<ma_container>/logs
 	}
 
 	# Required by Metrika Agent to track container state (i.e. restart, stop etc.)
 	@eventsurl {
 		method GET
-		path /v1.24/events
+		path /v1.41/events
 	}
 
 	reverse_proxy @containersurl unix///var/run/docker.sock

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,13 +1,5 @@
 # Thanks to https://raesene.github.io/blog/2021/09/05/restricting-docker-access-with-a-proxy/
-{
-	debug
-}
-
 http://127.0.0.1:2379 {
-	log {
-		level DEBUG
-	}
-
 	# Required by Metrika Agent for container discovery
 	@containersurl {
 		method GET

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -11,22 +11,19 @@ http://127.0.0.1:2379 {
 	# Required by Metrika Agent for container discovery
 	@containersurl {
 		method GET
-        header X-Ma-User metrikad
-		path_regexp /v1.24/containers/json
+		path /v1.24/containers/json
 	}
 
 	# Required by Metrika Agent to stream container logs
 	@containerlogsurl {
 		method GET
-        header X-Ma-User metrikad
-		path_regexp /v1.24/containers/dapper-private-network-consensus_1-1/logs
+		path /v1.24/containers/<ma_container>/logs
 	}
 
 	# Required by Metrika Agent to track container state (i.e. restart, stop etc.)
 	@eventsurl {
 		method GET
-        header X-Ma-User metrikad
-		path_regexp /v1.24/events
+		path /v1.24/events
 	}
 
 	reverse_proxy @containersurl unix///var/run/docker.sock

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,0 +1,36 @@
+{
+	debug
+}
+
+http://127.0.0.1:2379 {
+	log {
+		level DEBUG
+	}
+
+    # Required by Metrika Agent for container discovery
+	@containersurl {
+		method GET
+		path_regexp /v1.(24|41)/containers/json
+	}
+
+    # Required by Metrika Agent to stream container logs
+	@containerlogsurl {
+		method GET
+		path_regexp /v1.(24|41)/containers/dapper-private-network-consensus_1-1/logs
+	}
+
+    # Required by Metrika Agent to track container state (i.e. restart, stop etc.)
+	@eventsurl {
+		method GET
+		path_regexp /v1.(24|41)/events
+	}
+
+	reverse_proxy @containersurl unix///var/run/docker.sock
+	reverse_proxy @containerlogsurl unix///var/run/docker.sock
+	reverse_proxy @eventsurl unix///var/run/docker.sock
+}
+
+127.0.0.1:2379 {
+    # Drop requests with non-whitelisted paths
+	respond "Request matched no routes in the caddy config." 404
+}

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,3 +1,4 @@
+# Thanks to https://raesene.github.io/blog/2021/09/05/restricting-docker-access-with-a-proxy/
 {
 	debug
 }
@@ -7,22 +8,25 @@ http://127.0.0.1:2379 {
 		level DEBUG
 	}
 
-    # Required by Metrika Agent for container discovery
+	# Required by Metrika Agent for container discovery
 	@containersurl {
 		method GET
-		path_regexp /v1.(24|41)/containers/json
+        header X-Ma-User metrikad
+		path_regexp /v1.24/containers/json
 	}
 
-    # Required by Metrika Agent to stream container logs
+	# Required by Metrika Agent to stream container logs
 	@containerlogsurl {
 		method GET
-		path_regexp /v1.(24|41)/containers/dapper-private-network-consensus_1-1/logs
+        header X-Ma-User metrikad
+		path_regexp /v1.24/containers/dapper-private-network-consensus_1-1/logs
 	}
 
-    # Required by Metrika Agent to track container state (i.e. restart, stop etc.)
+	# Required by Metrika Agent to track container state (i.e. restart, stop etc.)
 	@eventsurl {
 		method GET
-		path_regexp /v1.(24|41)/events
+        header X-Ma-User metrikad
+		path_regexp /v1.24/events
 	}
 
 	reverse_proxy @containersurl unix///var/run/docker.sock
@@ -31,6 +35,6 @@ http://127.0.0.1:2379 {
 }
 
 127.0.0.1:2379 {
-    # Drop requests with non-whitelisted paths
+	# Drop requests with non-whitelisted paths
 	respond "Request matched no routes in the caddy config." 404
 }

--- a/internal/pkg/buf/ctrl.go
+++ b/internal/pkg/buf/ctrl.go
@@ -314,7 +314,7 @@ func (c *Controller) EmitEvent(ctx map[string]interface{}, name string) error {
 	}
 
 	if err := c.BufInsert(item); err != nil {
-		zap.S().Errorw("buffer insert error", err)
+		zap.S().Errorw("buffer insert error", zap.Error(err))
 
 		return err
 	}


### PR DESCRIPTION
This is a proposed setup to run the Metrika Agent behind a reverse proxy, using [Caddy Server](https://caddyserver.com/).

This method doesn't require the `metrikad` user to be added to the `docker` group. Instead the agent can run without elevated privileges.

You can test the setup in this branch by running caddy on the foreground:

```bash
caddy run --watch --config caddy/Caddyfile
```

and start the agent by overriding the `DOCKER_HOST` env var to:

```bash
export DOCKER_HOST=tcp://127.0.0.1:2379
```