### PR TITLE
Fix goroutine leaks

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -273,6 +273,7 @@ func (d *Flow) configurePEFEndpoints() error {
 		if err != nil {
 			continue
 		}
+		defer resp.Body.Close()
 		if resp.StatusCode <= 204 {
 			zap.S().Infow("found PEF metrics", "endpoint", endpoint)
 			// MetricEndpoints[0].URL is hardcoded as "" in template

--- a/internal/pkg/publisher/publisher_test.go
+++ b/internal/pkg/publisher/publisher_test.go
@@ -287,6 +287,10 @@ func TestPublisher_Error(t *testing.T) {
 
 	tr, err := transport.NewPlatformGRPC(transportConf)
 	require.Nil(t, err)
+	tr.GrpcErrHandler = func() error {
+		tr.AgentService = nil
+		return nil
+	}
 
 	bufCtrlConf := buf.ControllerConf{
 		BufLenLimit:         conf.MaxBatchLen,

--- a/internal/pkg/transport/transport.go
+++ b/internal/pkg/transport/transport.go
@@ -177,7 +177,7 @@ func (t *PlatformGRPC) PublishFunc(b buf.ItemBatch) error {
 		batch = append(batch, m)
 	}
 
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	go func() {
 		timestamp, err := t.Publish(batch)
 		if err != nil {

--- a/internal/pkg/transport/transport.go
+++ b/internal/pkg/transport/transport.go
@@ -106,7 +106,7 @@ func (t *PlatformGRPC) Publish(data []*model.Message) (int64, error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*t.TransmitTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), t.TransmitTimeout)
 	defer cancel()
 
 	metrikaMsg := model.PlatformMessage{

--- a/internal/pkg/transport/transport.go
+++ b/internal/pkg/transport/transport.go
@@ -131,6 +131,7 @@ func (t *PlatformGRPC) Publish(data []*model.Message) (int64, error) {
 
 		// mark service for repair
 		t.AgentService = nil
+		t.grpcConn.Close()
 
 		return 0, err
 	}


### PR DESCRIPTION
1. `http.Client` goroutines were kept idle after flow node's PEF endpoint discovery.
2. `grpc.ClientConn` not closed in the retry logic.