### PR TITLE
fixup: strip binaries when linking.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ generate-%: $(PROTOBIND)
 .PHONY: build-%-dbg
 build-%-dbg: generate-%
 	echo "Building Metrikad agent: GOOS: $(GOOS) GOARCH: $(GOARCH) PROTO: ${*}"
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o=metrikad-${*}-$(GOOS)-$(GOARCH)-dbg -tags=${*} -ldflags=" \
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o=metrikad-${*}-$(GOOS)-$(GOARCH) -tags=${*} -ldflags=" \
 	-X 'agent/internal/pkg/global.Version=${VERSION}' \
 	-X 'agent/internal/pkg/global.CommitHash=${HASH}' \
 	-X 'agent/internal/pkg/global.Blockchain=${*}' \

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,8 @@ generate-%: $(PROTOBIND)
 build-%: generate-%
 	echo "Building Metrikad agent: GOOS: $(GOOS) GOARCH: $(GOARCH) PROTO: ${*}"
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o=metrikad-${*}-$(GOOS)-$(GOARCH) -tags=${*} -ldflags=" \
+	-s \
+	-w \
 	-X 'agent/internal/pkg/global.Version=${VERSION}' \
 	-X 'agent/internal/pkg/global.CommitHash=${HASH}' \
 	-X 'agent/internal/pkg/global.Blockchain=${*}' \


### PR DESCRIPTION
This PR adds `-s -w` to the ldflags option so that produced binaries are stripped of their symbols. This reduces the size of the agent from ~20M to ~14M.

My suggestion is that we refactor this slightly to add a debug build option so that developers can easily build binaries with symbols, if necessary. cc @tomasger @iogakos 