### PR TITLE
Build and publish Docker images

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,9 +28,34 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+      - name: Sanitize repo slug
+        uses: actions/github-script@v6
+        id: repo_slug
+        with:
+          result-encoding: string
+          script: return 'ghcr.io/${{ github.repository }}'.toLowerCase()
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v2
+        with:
+          images: ${{ steps.repo_slug.outputs.result }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+
+      - name: Build and push Docker Flow images
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true
-          tags: Metrika-Inc/agent:nightly
+          file: docker/Dockerfile
+          # FIXME: Investigate Dockerfile problems with linux/arm64
+          platforms: linux/amd64
+          build-args: |
+            MA_PROTOCOL=flow
+            MA_VERSION=${{ steps.meta.outputs.version }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,8 +52,7 @@ jobs:
           context: .
           push: true
           file: docker/Dockerfile
-          # FIXME: Investigate Dockerfile problems with linux/arm64
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             MA_PROTOCOL=flow
             MA_VERSION=${{ steps.meta.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,17 +130,34 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Sanitize repo slug
+        uses: actions/github-script@v6
+        id: repo_slug
+        with:
+          result-encoding: string
+          script: return 'ghcr.io/${{ github.repository }}'.toLowerCase()
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v2
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ steps.repo_slug.outputs.result }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+
+      - name: Build and push Docker Flow images
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            MA_PROTOCOL=flow
+            MA_VERSION=${{ steps.meta.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,12 @@ build: $(PROTOBIND) $(foreach b,$(PROTOS),build-$(b)-strip)
 .PHONY: build-dbg
 build-dbg: $(PROTOBIND) $(foreach b,$(PROTOS),build-$(b)-dbg)
 
+.PHONY: docker-build-linux-amd64
+docker-build-linux-amd64: $(PROTOBIND) linux-amd64-env $(foreach b,$(PROTOS),docker-build-$(b))
+
+.PHONY: docker-build-linux-arm64
+docker-build-linux-arm64: $(PROTOBIND) linux-arm64-env $(foreach b,$(PROTOS),docker-build-$(b))
+
 .PHONY: docker-build
 docker-build: $(PROTOBIND) $(foreach b,$(PROTOS),docker-build-$(b))
 

--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,10 @@ checksum-%:
 .PHONY: docker-build-%
 docker-build-%: generate-%
 	echo "Building Metrikad Docker agent"
-	$(DOCKER) build -f $(DOCKERFILE) \
+	$(DOCKER) build --platform $(GOOS)/$(GOARCH) -f $(DOCKERFILE) \
 		-t metrikad-${*}:${VERSION} \
 		--build-arg MA_PROTOCOL=${*} \
-		--build-arg MA_VERSION=${VERSION} \
-		--build-arg MA_OS_ARCH=$(GOARCH) .
+		--build-arg MA_VERSION=${VERSION} .
 
 .PHONY: protogen
 protogen:
@@ -172,9 +171,6 @@ docker-build-linux-amd64: $(PROTOBIND) linux-amd64-env $(foreach b,$(PROTOS),doc
 
 .PHONY: docker-build-linux-arm64
 docker-build-linux-arm64: $(PROTOBIND) linux-arm64-env $(foreach b,$(PROTOS),docker-build-$(b))
-
-.PHONY: docker-build
-docker-build: $(PROTOBIND) $(foreach b,$(PROTOS),docker-build-$(b))
 
 .PHONY: clean-%
 clean-%:

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This covers a subset of configuration options that are most likely to be changed
 * `platform.api_key` - configured during install, an API key used for communicating with Metrika Platform. It maps the agent with your account.
 * `buffer.max_heap_alloc` - maximum allowed allocations in heap (in bytes). Acts as a limit to prevent unlimited buffering. Default: `50MB`.
 * `runtime.logging.outputs` - where Metrika outputs logs, can specify multiple sources. Default: `stdout` (journalctl). **Warning**: Metrika Agent does not take care of rotating the logs.
-* `runtime.logging.level` - verbosity of the logs. Default - `warning`. Recommended to increase to `debug` when troubleshooting.
+* `runtime.logging.level` - verbosity of the logs. Default - `info`. Recommended to increase to `debug` when troubleshooting.
 * `runtime.exporters` **(work in progress)** - enable other exporters. More on this in [Exporter API](#exporter-api). Default: `false`.
 * `runtime.watchers` - list of enabled watchers (collectors). More on this in [Watchers](#watchers).
 

--- a/configs/agent.yml
+++ b/configs/agent.yml
@@ -54,8 +54,8 @@ runtime:
 
     # level: logging level for runtime logs.
     #
-    # Possible values are: info, warning (recommended), debug, error.
-    level: warning
+    # Possible values are: info (recommended), warning, debug, error.
+    level: info
 
   # disable_fingerprint_validation: disables fingerprint validation on startup.
   #

--- a/configs/flow.template
+++ b/configs/flow.template
@@ -4,6 +4,8 @@ envFile: {{ or .EnvFilePath "/etc/flow/runtime-conf.env" }}
 containerRegex:{{ range .ContainerRegex }}
   - {{ . }}{{else}}
   - flow-go
+  - dapper-private-network-consensus_1-1
+  - flow-private-network-consensus_1-1
   - dapper-private-network_consensus_1_1
   - flow-private-network_consensus_1_1{{end}}
 pefEndpoints:{{ range .PEFEndpoints }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,13 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.18.6 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.6 as builder
 
 WORKDIR /build
 
 # build args
 ARG MA_VERSION
 ARG MA_PROTOCOL
+ARG TARGETARCH
+ARG BUILDOS
 
 # Note: git clone is not required when building locally.
 RUN git clone --depth=1 --branch ${MA_VERSION} --single-branch https://github.com/Metrika-Inc/agent.git
@@ -14,17 +16,32 @@ RUN git clone --depth=1 --branch ${MA_VERSION} --single-branch https://github.co
 # COPY . ./agent
 
 WORKDIR /build/agent
-RUN make build-${MA_PROTOCOL}-strip
+RUN make build-$BUILDOS-$TARGETARCH
 
-FROM bitnami/minideb:bullseye
+FROM --platform=$BUILDPLATFORM bitnami/minideb:bullseye
 
 # build-args
 ARG MA_PROTOCOL
-ARG MA_OS_ARCH
+ARG TARGETARCH
+ARG BUILDOS
+
+RUN ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split
+RUN ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb
+RUN ln -s /bin/rm /usr/sbin/rm
+RUN ln -s /bin/tar /usr/sbin/tar
+RUN ln -s /bin/nscd /usr/sbin/nscd
+RUN ln -s /bin/sss_cache /usr/sbin/sss_cache
 
 # Enable TLS
 RUN apt-get update && \
     apt-get install -y ca-certificates openssl
+
+RUN if [ "$TARGETARCH" = "arm64" ] ; then \
+    dpkg --add-architecture arm64 && \
+    apt-get install -y pkg-config && \
+    dpkg-configure -a && \
+    apt-get install -y qemu-user-static nscd sssd-tools;\
+fi
 
 # Create metrikad and configure permissions for agent directories.
 # This user is required when agent is run by a non-root user, for example
@@ -36,7 +53,7 @@ RUN chown -R metrikad: /etc/metrikad /opt/metrikad
 RUN chmod u+rw /etc/metrikad/configs /opt/metrikad/.cache
 
 # Copy agent binary and configuration
-COPY --from=builder "/build/agent/metrikad-${MA_PROTOCOL}-linux-${MA_OS_ARCH}" "/opt/metrikad/metrikad-${MA_PROTOCOL}"
+COPY --from=builder "/build/agent/metrikad-$MA_PROTOCOL-$BUILDOS-$TARGETARCH" "/opt/metrikad/metrikad-$MA_PROTOCOL"
 COPY --from=builder /build/agent/configs /etc/metrikad/configs
 
 # remove setuid and setgid permission from binaries

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,30 +18,16 @@ RUN git clone --depth=1 --branch ${MA_VERSION} --single-branch https://github.co
 WORKDIR /build/agent
 RUN make build-$BUILDOS-$TARGETARCH
 
-FROM --platform=$BUILDPLATFORM bitnami/minideb:bullseye
+FROM --platform=$BUILDPLATFORM alpine:3
 
 # build-args
 ARG MA_PROTOCOL
 ARG TARGETARCH
 ARG BUILDOS
 
-RUN ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split
-RUN ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb
-RUN ln -s /bin/rm /usr/sbin/rm
-RUN ln -s /bin/tar /usr/sbin/tar
-RUN ln -s /bin/nscd /usr/sbin/nscd
-RUN ln -s /bin/sss_cache /usr/sbin/sss_cache
-
 # Enable TLS
-RUN apt-get update && \
-    apt-get install -y ca-certificates openssl
-
-RUN if [ "$TARGETARCH" = "arm64" ] ; then \
-    dpkg --add-architecture arm64 && \
-    apt-get install -y pkg-config && \
-    dpkg-configure -a && \
-    apt-get install -y qemu-user-static nscd sssd-tools;\
-fi
+RUN apk update && \
+    apk add ca-certificates openssl
 
 # Create metrikad and configure permissions for agent directories.
 # This user is required when agent is run by a non-root user, for example


### PR DESCRIPTION
- Use docker/build-push-action@v3 to build and publish multi-platform Docker images.
- Switch to `alpine:3` images for agent execution since bitnami docker images don't support `arm64` architectures yet. See https://github.com/bitnami/charts/issues/7305 for details
- Decrease default logging level to `info` because `warning` produces no logs in a steady state making it hard to reason for liveness.