### PR TITLE
Fix docker events subscription with invalid name

### DIFF
--- a/internal/pkg/watch/docker_container.go
+++ b/internal/pkg/watch/docker_container.go
@@ -170,7 +170,7 @@ func (w *ContainerWatch) parseDockerEvent(m events.Message) (*model.Event, error
 	case "restart":
 		ev, err = model.NewWithCtx(ctx, model.AgentNodeRestartName, timesync.Now())
 		w.containerGone = false
-	case "die":
+	case "die", "stop", "kill":
 		exitCode, ok := m.Actor.Attributes["exit_code"]
 		if ok {
 			ctx["exit_code"] = exitCode

--- a/internal/pkg/watch/docker_container.go
+++ b/internal/pkg/watch/docker_container.go
@@ -138,8 +138,10 @@ func (w *ContainerWatch) repairEventStream(ctx context.Context) (
 	filter.Add("status", "stop")
 	filter.Add("status", "kill")
 	filter.Add("status", "die")
-	filter.Add("container", container.Names[0])
+	filter.Add("container", container.ID)
+
 	options := dt.EventsOptions{Filters: filter}
+	zap.S().Debug("subscribing to docker event stream", "filter", filter)
 
 	msgchan, errchan, err := utils.DockerEvents(ctx, options)
 	if err != nil {


### PR DESCRIPTION
Docker container list api names come with a leading forward slash (i.e. /flow-go) and without trimming the event filter is broken causing the agent to lose container events. In any case use container id for subscription for safety.