### PR TITLE
Fix nightly CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v2
+        uses: docker/metadata-action@v4
         with:
           images: ${{ steps.repo_slug.outputs.result }}
           tags: nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,8 +2,7 @@
 name: "Release"
 on:
   schedule:
-#    - cron: '10 0 * * *'
-    - cron: '20 17 * * *'
+    - cron: '0 0 * * *'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,7 @@ jobs:
         uses: docker/metadata-action@v2
         with:
           images: ${{ steps.repo_slug.outputs.result }}
+          tags: nightly
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -54,6 +55,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             MA_PROTOCOL=flow
-            MA_VERSION=${{ steps.meta.outputs.version }}
+            MA_VERSION=main
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,5 @@
 ---
-name: "Release"
+name: "Release Docker images (nightly)"
 on:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v2
+        uses: docker/metadata-action@v4
         with:
           images: ${{ steps.repo_slug.outputs.result }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 ---
-name: "Release"
+name: "Release standalone binaries and Docker images"
 on:
   push:
     tags:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    name: Release
+    name: Build and release all
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Addresses the latest failed [attempt](https://github.com/Metrika-Inc/agent/actions/runs/3283877169) of the nightly CI that publishes Docker images.

Fixed by setting the `MA_VERSION` to `main` branch and using tag `nightly`. I tested the PR [here](https://github.com/Metrika-Inc/agent/actions/runs/3284766523) (though that test was using tag `latest` instead of `nightly`). 