### PR TITLE
Reverts cc2d575df7 as container.ID filter is not picking up docker events

### DIFF
--- a/internal/pkg/watch/docker_container.go
+++ b/internal/pkg/watch/docker_container.go
@@ -16,6 +16,7 @@ package watch
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"agent/api/v1/model"
@@ -138,7 +139,11 @@ func (w *ContainerWatch) repairEventStream(ctx context.Context) (
 	filter.Add("status", "stop")
 	filter.Add("status", "kill")
 	filter.Add("status", "die")
-	filter.Add("container", container.ID)
+
+	// Docker container list api names come with a forward slash
+	// which breaks the container filter below if not stripped.
+	containerName := strings.TrimPrefix(container.Names[0], "/")
+	filter.Add("container", containerName)
 
 	options := dt.EventsOptions{Filters: filter}
 	zap.S().Debug("subscribing to docker event stream", "filter", filter)

--- a/internal/pkg/watch/docker_container.go
+++ b/internal/pkg/watch/docker_container.go
@@ -146,7 +146,7 @@ func (w *ContainerWatch) repairEventStream(ctx context.Context) (
 	filter.Add("container", containerName)
 
 	options := dt.EventsOptions{Filters: filter}
-	zap.S().Debug("subscribing to docker event stream", "filter", filter)
+	zap.S().Debugw("subscribing to docker event stream", "filter", filter)
 
 	msgchan, errchan, err := utils.DockerEvents(ctx, options)
 	if err != nil {


### PR DESCRIPTION
I tested this with:
```
✗ docker version      alerthub-sandboxes
Client: Docker Engine - Community
 Version:           20.10.19
 API version:       1.41
 Go version:        go1.18.7
 Git commit:        d85ef84
 Built:             Thu Oct 13 16:46:45 2022
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server: Docker Engine - Community
 Engine:
  Version:          20.10.19
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.18.7
  Git commit:       c964641
  Built:            Thu Oct 13 16:44:36 2022
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.8
  GitCommit:        9cd3357b7fd7218e4aec3eae239db1f68a5a6ec6
 runc:
  Version:          1.1.4
  GitCommit:        v1.1.4-0-g5fd4c4d
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0

```
@tomasger Would be helpful if you'd try running this on your setup.