### PR TITLE
Fallback to loading Flow env from env file only when metadata extraction fails from docker cmd shell args.

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -147,6 +147,7 @@ func (d *Flow) DiscoverContainer() (*types.Container, error) {
 		log.Warnw("could not find node ID in docker container cmd args", zap.Error(err))
 		errs.Append(err)
 
+		// fall back to environment file
 		if _, err := d.configureNodeIDFromEnvFile(); err != nil {
 			log.Warnw("could not find node ID in env file", zap.Error(err))
 			errs.Append(err)


### PR DESCRIPTION
This reduces log verbosity when node discovery occurs as it only tries to load the env file if node id extraction fails from docker cmd arguments.