### PR TITLE
Remove -linkmode=external as it's only applicable with CGO_ENABLED

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,6 @@ build-%-strip: generate-%
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -buildmode=pie -o=metrikad-${*}-$(GOOS)-$(GOARCH) -tags=${*} -ldflags=" \
 	-s \
 	-w \
-	-linkmode=external \
 	-extldflags=-Wl,-z,relro,-z,now \
 	-X 'agent/internal/pkg/global.Version=${VERSION}' \
 	-X 'agent/internal/pkg/global.CommitHash=${HASH}' \


### PR DESCRIPTION
Fixes broken builds.