### PR TITLE
Host header validation and local endpoint documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,18 @@ Agent issues can be troubleshot with the help of logs. By default agent logs can
 journalctl -u metrikad-{blockchain}.service
 ```
 
+You can modify the logging level without restarting the agent by sending an HTTP PUT request to the `/loglvl` endpoint:
+```sh
+curl -X PUT 127.0.0.1:9000/loglvl -d level=debug
+```
+
+### Prometheus Metrics
+The agent listens for HTTP requests on the address specified by `runtime.metrics_addr`. You can scrape Prometheus metrics by hitting the `/metrics` endpoint, for example:
+
+```sh
+curl 127.0.0.1:9000/metrics
+```
+
 ### Blockchain Node Discovery Issues
 The Metrika Agent attempts to discover a supported running blockchain node in the system. In case the blockchain node is containerized, Agent attempts to find the container by matching container name or image to a list of regular expressions specified in `/etc/metrikad/configs/{blockchain}.yml`. If the container name is not in the list of common names Metrika Agent is aware of, it can be added to the list of `containerRegex` in the aforementioned configuration file.
 

--- a/api/v1/model/event.go
+++ b/api/v1/model/event.go
@@ -71,8 +71,7 @@ const (
 	// AgentNetErrorName The agent failed to send data to the backend. Ctx: error
 	AgentNetErrorName = "agent.net.error"
 
-	// AgentHealthName The agent self-test results
-	// TODO: not implemented
+	// AgentHealthName The agent self-test results (not implemented)
 	AgentHealthName = "agent.health"
 
 	/* chain specific events */
@@ -89,15 +88,13 @@ const (
 	// AgentNodeLogMissingName The node log file has gone missing. Ctx: node_id, node_type, node_version
 	AgentNodeLogMissingName = "agent.node.log.missing"
 
-	// AgentNodeConfigMissingName The node configuration file has gone missing
-	// TODO: not implemented
+	// AgentNodeConfigMissingName The node configuration file has gone missing (not implemented)
 	AgentNodeConfigMissingName = "agent.node.config.missing"
 
 	// AgentNodeLogFoundName The node log file has been found. Ctx: node_id, node_type,  node_version
 	AgentNodeLogFoundName = "agent.node.log.found"
 
-	// AgentConfigMissingName The agent configuration has gone missing
-	// TODO: not implemented
+	// AgentConfigMissingName The agent configuration has gone missing (not implemented)
 	AgentConfigMissingName = "agent.config.missing"
 
 	// AgentClockSyncName The agent synchronized its clock to NTP. Ctx: offset_millis, ntp_server

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -213,7 +213,7 @@ func main() {
 
 	httpwg := &sync.WaitGroup{}
 	httpwg.Add(1)
-	httpsrv := mahttp.StartHTTPServer(httpwg, global.AgentConf.Runtime.MetricsAddr)
+	httpsrv := mahttp.StartHTTPServer(httpwg, global.AgentConf.Runtime.HTTPAddr)
 	http.Handle("/metrics", mahttp.ValidationMiddleware(promHandler))
 	http.Handle("/loglvl", mahttp.ValidationMiddleware(zapLevelHandler))
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -214,7 +214,9 @@ func main() {
 	httpwg := &sync.WaitGroup{}
 	httpwg.Add(1)
 	httpsrv := mahttp.StartHTTPServer(httpwg, global.AgentConf.Runtime.HTTPAddr)
-	http.Handle("/metrics", mahttp.ValidationMiddleware(promHandler))
+	if global.AgentConf.Runtime.MetricsEnabled {
+		http.Handle("/metrics", mahttp.ValidationMiddleware(promHandler))
+	}
 	http.Handle("/loglvl", mahttp.ValidationMiddleware(zapLevelHandler))
 
 	log := zap.S()

--- a/configs/agent.yml
+++ b/configs/agent.yml
@@ -69,6 +69,9 @@ runtime:
   #  - Update its logging level (PUT /loglvl).
   http_addr: 127.0.0.1:9000
 
+  # metrics_enabled: bool, enable prometheus /metrics endpoint. Default is false.
+  metrics_enabled: false
+
   # allowed_hosts: list[string], list of allowed Host HTTP headers to check when
   # validating HTTP requests processed by the agent such as /metrics. Use
   # comma-separated format when configuring this with an environment variable.

--- a/configs/agent.yml
+++ b/configs/agent.yml
@@ -64,9 +64,10 @@ runtime:
   # not match. Checksum is cached under $HOME/.cache/metrikad/fingerprint.
   disable_fingerprint_validation: false
 
-  # metrics_addr: string, network address to get Prometheus metrics about the
-  # agent's runtime.
-  metrics_addr: 127.0.0.1:9000
+  # http_addr: string, network address to listen for HTTP requests to:
+  #  - Get Prometheus metrics about the agent's runtime (GET /metrics).
+  #  - Update its logging level (PUT /loglvl).
+  http_addr: 127.0.0.1:9000
 
   # allowed_hosts: list[string], list of allowed Host HTTP headers to check when
   # validating HTTP requests processed by the agent such as /metrics. Use

--- a/configs/agent.yml
+++ b/configs/agent.yml
@@ -68,6 +68,12 @@ runtime:
   # agent's runtime.
   metrics_addr: 127.0.0.1:9000
 
+  # allowed_hosts: list[string], list of allowed Host HTTP headers to check when
+  # validating HTTP requests processed by the agent such as /metrics. Use
+  # comma-separated format when configuring this with an environment variable.
+  allowed_hosts:
+    - 127.0.0.1
+
   # sampling_interval: duration, default interval used by Watchers that use
   # polling for collecting metrics/events.
   sampling_interval: 5s

--- a/contrib/ansible/roles/metrika-agent-install/tasks/main.yml
+++ b/contrib/ansible/roles/metrika-agent-install/tasks/main.yml
@@ -7,8 +7,7 @@
   user:
     name: metrika-agent
     comment: Metrika agent user
-    # TODO - After implementing the docker proxy, remove the docker group from this user
-    groups: "metrika-agent, docker"
+    groups: "metrika-agent"
     shell: /sbin/nologin
     create_home: yes
     state: present

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -374,9 +374,6 @@ func (d *Flow) Network() string {
 // until it discovers both node role and network properties.
 func (d *Flow) updateFromLogs(containerName string) error {
 	if d.nodeRole != "" && d.network != "" {
-		// TODO: node type discovery is quite expensive
-		// and we are not handling role changes for now
-		// so ignore further calls.
 		return nil
 	}
 

--- a/install.sh
+++ b/install.sh
@@ -141,7 +141,6 @@ function download_agent {
 		# This is not a custom install. We'll check and get the binary from Github.
 		case $IS_UPDATABLE in
 		1)
-			# TODO(cosmix): add the architecture here when we add multiarch support.
 			download_url=$(echo "${gh_response}" | grep "url" | grep "browser_download_url" | grep "${MA_BLOCKCHAIN}" | cut -f 4 -d "\"" | tr -d '",' | grep ${HOST_ARCH} | grep -v "sha256" | xargs)
 
 			binary="$BIN_NAME-$HOST_OS-$HOST_ARCH"
@@ -220,8 +219,6 @@ function sanity_check {
 		;;
 	esac
 
-	# TODO: remove MA_PLATFORM dependency.
-	# MA_PLATFORM envvar
 	if [[ -z "${PLATFORM_ADDR}" ]]; then
 		if [[ -z "${MA_PLATFORM}" ]]; then
 			goodbye "MA_PLATFORM environment variable must be set'. Goodbye." 100

--- a/internal/pkg/discover/mock.go
+++ b/internal/pkg/discover/mock.go
@@ -30,35 +30,34 @@ func (m *MockBlockchain) Protocol() string {
 
 // IsConfigured ...
 func (m *MockBlockchain) IsConfigured() bool {
-	panic("not implemented") // TODO: Implement
+	panic("not implemented")
 }
 
 // ResetConfig ...
 func (m *MockBlockchain) ResetConfig() error {
-	panic("not implemented") // TODO: Implement
+	panic("not implemented")
 }
 
 // PEFEndpoints returns a list of HTTP endpoints with PEF data to be sampled.
 func (m *MockBlockchain) PEFEndpoints() []global.PEFEndpoint {
-	panic("not implemented") // TODO: Implement
+	panic("not implemented")
 }
 
 // ContainerRegex returns a regex-compatible strings to identify the blockchain node
 // if it is running as a docker container.
 func (m *MockBlockchain) ContainerRegex() []string {
-	panic("not implemented") // TODO: Implement
+	panic("not implemented")
 }
 
 // LogEventsList returns a map containing all the blockchain node related events meant to be sampled.
 func (m *MockBlockchain) LogEventsList() map[string]model.FromContext {
-	panic("not implemented") // TODO: Implement
+	panic("not implemented")
 }
 
 // NodeLogPath returns the path to the log file to watch.
 // Supports special keys like "docker" or "journald <service-name>"
-// TODO: string -> []string perhaps
 func (m *MockBlockchain) NodeLogPath() string {
-	panic("not implemented") // TODO: Implement
+	panic("not implemented")
 }
 
 // NodeID ...

--- a/internal/pkg/global/agent.go
+++ b/internal/pkg/global/agent.go
@@ -74,7 +74,6 @@ type Chain interface {
 
 	// NodeLogPath returns the path to the log file to watch.
 	// Supports special keys like "docker" or "journald <service-name>"
-	// TODO: string -> []string perhaps
 	NodeLogPath() string
 
 	// NodeID returns the blockchain node id

--- a/internal/pkg/global/config.go
+++ b/internal/pkg/global/config.go
@@ -103,8 +103,8 @@ var (
 	// DefaultRuntimeDisableFingerprintValidation default fingerprint validation policy
 	DefaultRuntimeDisableFingerprintValidation = false
 
-	// DefaultRuntimeMetricsAddr default address to expose Prometheus metrics
-	DefaultRuntimeMetricsAddr = "127.0.0.1:9000"
+	// DefaultRuntimeHTTPAddr default address to expose Prometheus metrics
+	DefaultRuntimeHTTPAddr = "127.0.0.1:9000"
 
 	// DefaultRuntimeAllowedHosts default list of allowed HTTP host headers
 	DefaultRuntimeAllowedHosts = []string{"127.0.0.1"}
@@ -167,7 +167,7 @@ type WatchConfig struct {
 
 // RuntimeConfig configuration related to the agent runtime.
 type RuntimeConfig struct {
-	MetricsAddr                  string                 `yaml:"metrics_addr"`
+	HTTPAddr                     string                 `yaml:"metrics_addr"`
 	AllowedHosts                 []string               `yaml:"allowed_hosts"`
 	Log                          LogConfig              `yaml:"logging"`
 	SamplingInterval             time.Duration          `yaml:"sampling_interval"`
@@ -310,7 +310,7 @@ func overloadFromEnv() error {
 
 	v = os.Getenv(strings.ToUpper(ConfigEnvPrefix + "_" + "runtime_metrics_addr"))
 	if v != "" {
-		AgentConf.Runtime.MetricsAddr = v
+		AgentConf.Runtime.HTTPAddr = v
 	}
 
 	v = os.Getenv(strings.ToUpper(ConfigEnvPrefix + "_" + "runtime_allowed_hosts"))
@@ -393,8 +393,8 @@ func ensureDefaults() {
 		AgentConf.Runtime.Log.Lvl = DefaultRuntimeLoggingLevel
 	}
 
-	if AgentConf.Runtime.MetricsAddr == "" {
-		AgentConf.Runtime.MetricsAddr = DefaultRuntimeMetricsAddr
+	if AgentConf.Runtime.HTTPAddr == "" {
+		AgentConf.Runtime.HTTPAddr = DefaultRuntimeHTTPAddr
 	}
 
 	if len(AgentConf.Runtime.AllowedHosts) == 0 {

--- a/internal/pkg/global/config.go
+++ b/internal/pkg/global/config.go
@@ -106,6 +106,9 @@ var (
 	// DefaultRuntimeMetricsAddr default address to expose Prometheus metrics
 	DefaultRuntimeMetricsAddr = "127.0.0.1:9000"
 
+	// DefaultRuntimeAllowedHosts default list of allowed HTTP host headers
+	DefaultRuntimeAllowedHosts = []string{"127.0.0.1"}
+
 	// ConfigEnvPrefix prefix used for agent specific env vars
 	ConfigEnvPrefix = "MA"
 )
@@ -165,6 +168,7 @@ type WatchConfig struct {
 // RuntimeConfig configuration related to the agent runtime.
 type RuntimeConfig struct {
 	MetricsAddr                  string                 `yaml:"metrics_addr"`
+	AllowedHosts                 []string               `yaml:"allowed_hosts"`
 	Log                          LogConfig              `yaml:"logging"`
 	SamplingInterval             time.Duration          `yaml:"sampling_interval"`
 	Watchers                     []*WatchConfig         `yaml:"watchers"`
@@ -309,6 +313,11 @@ func overloadFromEnv() error {
 		AgentConf.Runtime.MetricsAddr = v
 	}
 
+	v = os.Getenv(strings.ToUpper(ConfigEnvPrefix + "_" + "runtime_allowed_hosts"))
+	if v != "" {
+		AgentConf.Runtime.AllowedHosts = strings.Split(v, ",")
+	}
+
 	v = os.Getenv(strings.ToUpper(ConfigEnvPrefix + "_" + "runtime_sampling_interval"))
 	if v != "" {
 		vDur, err := time.ParseDuration(v)
@@ -386,6 +395,10 @@ func ensureDefaults() {
 
 	if AgentConf.Runtime.MetricsAddr == "" {
 		AgentConf.Runtime.MetricsAddr = DefaultRuntimeMetricsAddr
+	}
+
+	if len(AgentConf.Runtime.AllowedHosts) == 0 {
+		AgentConf.Runtime.AllowedHosts = DefaultRuntimeAllowedHosts
 	}
 
 	if AgentConf.Runtime.SamplingInterval == 0 {

--- a/internal/pkg/global/config.go
+++ b/internal/pkg/global/config.go
@@ -168,6 +168,7 @@ type WatchConfig struct {
 // RuntimeConfig configuration related to the agent runtime.
 type RuntimeConfig struct {
 	HTTPAddr                     string                 `yaml:"metrics_addr"`
+	MetricsEnabled               bool                   `yaml:"metrics_enabled"`
 	AllowedHosts                 []string               `yaml:"allowed_hosts"`
 	Log                          LogConfig              `yaml:"logging"`
 	SamplingInterval             time.Duration          `yaml:"sampling_interval"`

--- a/internal/pkg/global/config_test.go
+++ b/internal/pkg/global/config_test.go
@@ -103,7 +103,7 @@ platform:
 	require.Equal(t, []string{"stdout", "stderr"}, AgentConf.Runtime.Log.Outputs)
 	require.Equal(t, "info", AgentConf.Runtime.Log.Lvl)
 	require.Equal(t, true, AgentConf.Runtime.DisableFingerprintValidation)
-	require.Equal(t, "foobar:9000", AgentConf.Runtime.MetricsAddr)
+	require.Equal(t, "foobar:9000", AgentConf.Runtime.HTTPAddr)
 	require.Equal(t, 5*time.Second, AgentConf.Runtime.SamplingInterval)
 	require.Equal(t, []*WatchConfig{{Type: "foo", SamplingInterval: 5 * time.Second}, {Type: "bar", SamplingInterval: 5 * time.Second}}, AgentConf.Runtime.Watchers)
 }

--- a/internal/pkg/global/exporter_registry.go
+++ b/internal/pkg/global/exporter_registry.go
@@ -28,7 +28,6 @@ import (
 var DefaultExporterRegisterer = new(ExporterRegisterer)
 
 // DefaultExporterTimeout exporter channel send timeout
-// TODO: make timeout configurable per exporter basis
 var DefaultExporterTimeout = 5 * time.Second
 
 // Exporter interface describes the interface to be implemented for accessing

--- a/internal/pkg/mahttp/server.go
+++ b/internal/pkg/mahttp/server.go
@@ -1,0 +1,54 @@
+package mahttp
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+
+	"agent/internal/pkg/global"
+
+	"go.uber.org/zap"
+)
+
+// ValidationMiddleware is a middleware for validating HTTP requests
+// handled by the agent itself.
+func ValidationMiddleware(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		if r.Host == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		hostParts := strings.Split(r.Host, ":")
+
+		if len(hostParts) > 0 {
+			host := hostParts[0]
+			for _, allowedHost := range global.AgentConf.Runtime.AllowedHosts {
+				if allowedHost == host {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			zap.S().Errorw("got unexpected host header", "host", r.Host)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}
+
+	return http.HandlerFunc(fn)
+}
+
+// StartHTTPServer starts an HTTP server that listens on addr.
+func StartHTTPServer(wg *sync.WaitGroup, addr string) *http.Server {
+	s := &http.Server{Addr: addr}
+
+	go func() {
+		defer wg.Done()
+
+		if err := s.ListenAndServe(); err != http.ErrServerClosed {
+			zap.S().Errorw("ListenAndServe()", zap.Error(err))
+		}
+	}()
+
+	return s
+}

--- a/internal/pkg/mahttp/server_test.go
+++ b/internal/pkg/mahttp/server_test.go
@@ -1,0 +1,79 @@
+package mahttp
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"agent/internal/pkg/global"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartHTTPServer_HostHeaderValidation tests that HTTP servers
+// started by StartHTTPServer() and paths wrapped with ValidationMiddleware(),
+// validate host header and reject requests for which validation fails.
+func TestStartHTTPServer_HostHeaderValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		addr         string
+		endpoint     string
+		hostHeader   string
+		allowedHosts []string
+		expCode      int
+	}{
+		{
+			name:         "valid",
+			addr:         "127.0.0.1:9001",
+			endpoint:     "/metrics",
+			allowedHosts: []string{"127.0.0.1"},
+			hostHeader:   "127.0.0.1",
+			expCode:      200,
+		},
+		{
+			name:         "invalid host header",
+			addr:         "127.0.0.1:9001",
+			endpoint:     "/metrics",
+			allowedHosts: []string{"127.0.0.1"},
+			hostHeader:   "foobar",
+			expCode:      400,
+		},
+	}
+
+	promHandler := promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{EnableOpenMetrics: true})
+	http.Handle("/metrics", ValidationMiddleware(promHandler))
+
+	allowedHostsWas := global.AgentConf.Runtime.AllowedHosts
+	defer func() { global.AgentConf.Runtime.AllowedHosts = allowedHostsWas }()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			global.AgentConf.Runtime.AllowedHosts = tt.allowedHosts
+
+			wg := &sync.WaitGroup{}
+			wg.Add(1)
+			srv := StartHTTPServer(wg, tt.addr)
+			time.Sleep(1 * time.Second)
+
+			req, err := http.NewRequest("GET", "http://127.0.0.1:9001/metrics", nil)
+			require.Nil(t, err)
+			req.Host = tt.hostHeader
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expCode, resp.StatusCode)
+
+			httpctx, httpcancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer httpcancel()
+
+			err = srv.Shutdown(httpctx)
+			require.Nil(t, err)
+
+			wg.Wait()
+		})
+	}
+}

--- a/internal/pkg/watch/docker_container_test.go
+++ b/internal/pkg/watch/docker_container_test.go
@@ -183,7 +183,7 @@ func (d *DockerMockAdapterError) MatchContainer(containers []dt.Container, ident
 }
 
 func (d *DockerMockAdapterError) DockerLogs(ctx context.Context, container string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
-	panic("not implemented") // TODO: Implement
+	panic("not implemented")
 }
 
 func (d *DockerMockAdapterError) DockerEvents(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error, error) {

--- a/internal/pkg/watch/docker_logs.go
+++ b/internal/pkg/watch/docker_logs.go
@@ -73,8 +73,6 @@ func (w *DockerLogWatch) repairLogStream(ctx context.Context) (io.ReadCloser, er
 		ShowStderr: true,
 		Follow:     true,
 		Tail:       "0",
-		// TODO: restore offset from a WAL.
-		// Since: "2022-02-25T19:14:59.721119832Z",
 	}
 
 	var rc io.ReadCloser

--- a/internal/pkg/watch/utils_test.go
+++ b/internal/pkg/watch/utils_test.go
@@ -138,5 +138,3 @@ func TestDtoToOpenMetrics(t *testing.T) {
 		}
 	}
 }
-
-// TODO: get some metrics from collectors, or find histograms/summaries somewhere

--- a/pkg/collector/arp_linux.go
+++ b/pkg/collector/arp_linux.go
@@ -53,10 +53,6 @@ func getARPEntries() (map[string]uint32, error) {
 	return entries, nil
 }
 
-// TODO: This should get extracted to the github.com/prometheus/procfs package
-// to support more complete parsing of /proc/net/arp. Instead of adding
-// more fields to this function's return values it should get moved and
-// changed to support each field.
 func parseARPEntries(data io.Reader) (map[string]uint32, error) {
 	scanner := bufio.NewScanner(data)
 	entries := make(map[string]uint32)

--- a/pkg/collector/sockstat_linux.go
+++ b/pkg/collector/sockstat_linux.go
@@ -32,8 +32,7 @@ const (
 // Used for calculating the total memory bytes on TCP and UDP.
 var pageSize = os.Getpagesize()
 
-type sockStatCollector struct {
-}
+type sockStatCollector struct{}
 
 // NewSockStatCollector returns a new Collector exposing socket stats.
 func NewSockStatCollector() (prometheus.Collector, error) {
@@ -95,7 +94,6 @@ func (c *sockStatCollector) update(ch chan<- prometheus.Metric, isIPv6 bool, s *
 
 	// If sockstat contains the number of used sockets, export it.
 	if !isIPv6 && s.Used != nil {
-		// TODO: this must be updated if sockstat6 ever exports this data.
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
 				prometheus.BuildFQName(namespace, sockStatSubsystem, "sockets_used"),
@@ -187,7 +185,6 @@ func (c *sockStatCollector) updateDesc(ch chan<- *prometheus.Desc, isIPv6 bool, 
 
 	// If sockstat contains the number of used sockets, export it.
 	if !isIPv6 && s.Used != nil {
-		// TODO: this must be updated if sockstat6 ever exports this data.
 		ch <- prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, sockStatSubsystem, "sockets_used"),
 			"Number of IPv4 sockets in use.",

--- a/pkg/timesync/timesync.go
+++ b/pkg/timesync/timesync.go
@@ -195,7 +195,6 @@ func (t *TimeSync) waitForDone() {
 }
 
 func (t *TimeSync) setAdjustBool() {
-	// TODO: select sensible values for when it's appropriate to adjust timedrift
 	t.Lock()
 	defer t.Unlock()
 	if t.delta > 3*time.Second || t.delta < -500*time.Millisecond {


### PR DESCRIPTION
Changes:
- Move local HTTP server under pkg `mahttp` and implements Host header validation: reject requests without a Host header set or with Host header not included in configuration key `runtime.allowed_hosts`.
- Document `/metrics` and `/loglvl` endpoints in README.
- For clarity, rename `runtime.metrics_addr` to `runtime.http_addr`, since its value is used to all local HTTP endpoint and not just `/metrics`.