### PR TITLE
Remove unused code for PidOf and PidArgs

### DIFF
--- a/internal/pkg/discover/utils/utils.go
+++ b/internal/pkg/discover/utils/utils.go
@@ -15,17 +15,12 @@ package utils
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
-	"os/exec"
 	"regexp"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -161,42 +156,6 @@ func DockerEvents(ctx context.Context, options types.EventsOptions) (
 	<-chan events.Message, <-chan error, error,
 ) {
 	return DefaultDockerAdapter.DockerEvents(ctx, options)
-}
-
-// PidOf returns the PID of a specified process name.
-// If process is not found an os.ExitError is returned.
-// In case of abnormal output, strconv.NumError is returned.
-func PidOf(name string) (int, error) {
-	var err error
-	var ret int
-	// try pidof
-	output, err := exec.Command("pidof", "-s", name).Output()
-	if err != nil {
-		output, err = exec.Command("pgrep", "-n", name).Output()
-		if err != nil {
-			return 0, err
-		}
-	}
-
-	ret, err = strconv.Atoi(strings.Trim(string(output), "\n"))
-	if err != nil {
-		return 0, err
-	}
-	return ret, nil
-}
-
-// PidArgs returns a string slice of the command line arguments
-// of a specifid PID.
-// First element is the executable path.
-func PidArgs(pid int) ([]string, error) {
-	pidStr := strconv.Itoa(pid)
-
-	out, err := ioutil.ReadFile("/proc/" + pidStr + "/cmdline")
-	if err != nil {
-		return nil, err
-	}
-	args := bytes.Replace(out, []byte{0x0}, []byte{' '}, -1)
-	return strings.Fields(string(args)), nil
 }
 
 // GetEnvFromFile returns a map of environment variables parsed from a file.

--- a/internal/pkg/discover/utils/utils_test.go
+++ b/internal/pkg/discover/utils/utils_test.go
@@ -21,39 +21,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"regexp"
 	"testing"
 
 	dt "github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/require"
 )
-
-func TestPidOf(t *testing.T) {
-	pid := getRealPID(t)
-	require.NotEqual(t, 0, pid)
-
-	result, err := PidOf("404noPID")
-	require.Equal(t, 0, result)
-	expectedError := &exec.ExitError{}
-	require.ErrorAs(t, err, &expectedError)
-}
-
-func TestPidArgs(t *testing.T) {
-	t.Run("PidArgs happy case", func(t *testing.T) {
-		pid := getRealPID(t)
-		args, err := PidArgs(pid)
-		require.NoError(t, err)
-		require.GreaterOrEqual(t, 1, len(args))
-	})
-	t.Run("PidArgs pid not found", func(t *testing.T) {
-		pid := -123
-		args, err := PidArgs(pid)
-		require.Error(t, err)
-		require.Nil(t, args)
-	})
-
-}
 
 func TestGetEnvFromFile(t *testing.T) {
 	path := "testcases/correctEnvFile"
@@ -71,15 +44,6 @@ func TestGetEnvFromFile(t *testing.T) {
 			t.Fatalf("Could not find the env var %v = %v", k, v)
 		}
 	}
-}
-
-func getRealPID(t *testing.T) int {
-	pid, err := PidOf("init")
-	if err != nil {
-		pid, err = PidOf("systemd")
-	}
-	require.NoError(t, err)
-	return pid
 }
 
 func TestGetLogLine(t *testing.T) {


### PR DESCRIPTION
Note: use absolute paths or os.IsNotExist if this code is ever resurrected