### PR TITLE
Add config update system to fix HTTP watchers which start with empty …

### DIFF
--- a/internal/pkg/discover/mock.go
+++ b/internal/pkg/discover/mock.go
@@ -129,3 +129,8 @@ func (m *MockBlockchain) ReconfigureByDockerContainer(container *types.Container
 func (m *MockBlockchain) ReconfigureBySystemdUnit(unit *dbus.UnitStatus, reader io.ReadCloser) error {
 	return nil
 }
+
+// ConfigUpdateCh ...
+func (m *MockBlockchain) ConfigUpdateCh() chan global.ConfigUpdate {
+	return nil
+}

--- a/internal/pkg/watch/http_test.go
+++ b/internal/pkg/watch/http_test.go
@@ -1,0 +1,38 @@
+package watch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"agent/internal/pkg/global"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPWatch_URLUpdates(t *testing.T) {
+	w := NewHTTPWatch(HTTPWatchConf{
+		URL:         "prevurl",
+		URLIndex:    1,
+		URLUpdateCh: make(chan global.ConfigUpdate, 1),
+		Interval:    time.Hour,
+	})
+	w.StartUnsafe()
+
+	updCh := make(chan global.ConfigUpdate)
+	cupdStream := global.NewConfigUpdateStream(global.ConfigUpdateStreamConf{UpdatesCh: updCh})
+	err := cupdStream.Subscribe(global.PEFEndpointsKey, w.URLUpdateCh)
+	require.Nil(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cupdStream.Run(ctx)
+
+	updCh <- global.ConfigUpdate{Key: global.PEFEndpointsKey, Val: []global.PEFEndpoint{{}, {URL: "newurl"}}}
+	time.Sleep(10 * time.Millisecond)
+	w.Stop()
+	w.wg.Wait()
+
+	require.Equal(t, "newurl", w.URL)
+}

--- a/internal/pkg/watch/watch_test.go
+++ b/internal/pkg/watch/watch_test.go
@@ -112,6 +112,10 @@ func (m *mockBlockchain) SetDockerContainer(_ *types.Container) {
 func (m *mockBlockchain) SetSystemdService(_ *dbus.UnitStatus) {
 }
 
+func (m *mockBlockchain) ConfigUpdateCh() chan global.ConfigUpdate {
+	return nil
+}
+
 func TestWatch_EmitAgentNodeEvents(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
…URLs

Fixes a bug where HTTP watchers which start before container discovery completes, will never get their configuration updated. This breaks prometheus metric collection when the agent discovers the node for the first time.