### PR TITLE
Make ntp server dynamic

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -336,6 +336,8 @@ func main() {
 
 		os.Exit(1)
 	}
+	ctx := context.Background()
+	timesync.SetDefault(timesync.NewTimeSync(ctx, global.AgentConf.Runtime.NTPServer, 0))
 	zapLevelHandler := setupZapLogger()
 
 	chain, err := discover.AutoConfig(&global.AgentConf, reset)

--- a/configs/agent.yml
+++ b/configs/agent.yml
@@ -117,6 +117,9 @@ runtime:
     - type: prometheus.uname
     - type: prometheus.vmstat
 
+  # ntp_server : string, address of the NTP server to use for time synchronization.
+  ntp_server: pool.ntp.org
+
 discovery:
   # deactivated: bool, deactivates node discovery completely. Default: false.
   deactivated: false

--- a/internal/pkg/global/config.go
+++ b/internal/pkg/global/config.go
@@ -121,6 +121,9 @@ var (
 	// DefaultRuntimeWatchersInfluxUpstreamURL default URL to push InfluxDB metrics to
 	DefaultRuntimeWatchersInfluxUpstreamURL = ""
 
+	// DefaultNTPServer default NTP server
+	DefaultNTPServer = "pool.ntp.org"
+
 	// ConfigEnvPrefix prefix used for agent specific env vars
 	ConfigEnvPrefix = "MA"
 )
@@ -215,6 +218,7 @@ type RuntimeConfig struct {
 	Watchers                     []*WatchConfig         `yaml:"watchers"`
 	DisableFingerprintValidation bool                   `yaml:"disable_fingerprint_validation"`
 	Exporters                    map[string]interface{} `yaml:"exporters"`
+	NTPServer                    string                 `yaml:"ntp_server"`
 }
 
 // Hints node discovery hints
@@ -445,6 +449,11 @@ func overloadFromEnv(c *AgentConfig) error {
 		c.Discovery.Docker.Regex = patterns
 	}
 
+	v = os.Getenv(strings.ToUpper(ConfigEnvPrefix + "_" + "runtime_ntp_server"))
+	if v != "" {
+		c.Runtime.NTPServer = v
+	}
+
 	return nil
 }
 
@@ -528,6 +537,9 @@ func ensureDefaults(c *AgentConfig) {
 				wc.ListenAddr = DefaultRuntimeWatchersInfluxListenAddr
 			}
 		}
+	}
+	if len(c.Runtime.NTPServer) == 0 {
+		c.Runtime.NTPServer = DefaultNTPServer
 	}
 }
 

--- a/pkg/timesync/timesync.go
+++ b/pkg/timesync/timesync.go
@@ -56,6 +56,11 @@ const (
 // the agent.
 var Default = NewTimeSync(context.Background(), "pool.ntp.org", 0)
 
+// SetDefault overrides Default TimeSync instance
+func SetDefault(ts *TimeSync) {
+	Default = ts
+}
+
 // NewTimeSync constructor
 func NewTimeSync(ctx context.Context, host string, retries int) *TimeSync {
 	if retries <= 0 {


### PR DESCRIPTION
As we can't use official ntp server, we would like to customize it to use ours.
This is done by setting the environment variable MA_NTP_SERVER. If empty, the default one is used.