### PR TITLE
Fix bug causing agent to skip node version configuration when node is discovered

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -507,10 +507,8 @@ func (d *Flow) nodeVersionFromDocker() (string, error) {
 		return "", fmt.Errorf("empty version in image parts")
 	}
 
-	d.nodeVersion = nodeVersionDocker
-
 	zap.S().Infow("updated node version (Docker)", "version", nodeVersionDocker)
-	return d.nodeVersion, nil
+	return nodeVersionDocker, nil
 }
 
 // Protocol returns "flow"

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -462,7 +462,7 @@ func (d *Flow) updateNodeVersion() (string, error) {
 		return "", fmt.Errorf("got empty version by docker container tag, is the image tagged?")
 	}
 
-	return "", fmt.Errorf("could not update node version from PEF/Docker")
+	return "", fmt.Errorf("node version not found in PEF/Docker")
 }
 
 func (d *Flow) nodeVersionFromPEF() (string, error) {

--- a/flow/testdata/containers.json
+++ b/flow/testdata/containers.json
@@ -2,7 +2,7 @@
     {
         "CreatedAt": "2022-03-06 18:55:52 +0000 UTC",
         "ID": "3076fe58cd89",
-        "Image": "localnet-consensus",
+        "Image": "localnet-consensus:v0.0.99",
         "Names": ["flow-private-network_consensus_2_1"],
         "Ports": [{}],
         "State": "running",
@@ -11,7 +11,7 @@
     {
         "CreatedAt": "2022-03-06 18:55:52 +0000 UTC",
         "ID": "fe4b24f231ee",
-        "Image": "localnet-consensus",
+        "Image": "localnet-consensus:v0.0.99",
         "Names": ["flow-private-network_consensus_3_1"],
         "Ports": [{}],
         "State": "running",
@@ -20,7 +20,7 @@
     {
         "CreatedAt": "2022-03-06 18:55:52 +0000 UTC",
         "ID": "98acb98ec332",
-        "Image": "localnet-collection",
+        "Image": "localnet-collection:v0.0.99",
         "Names": ["flow-private-network_collection_3_1"],
         "Ports": [{}],
         "State": "running",
@@ -29,7 +29,7 @@
     {
         "CreatedAt": "2022-03-06 18:55:52 +0000 UTC",
         "ID": "adebaf04b450",
-        "Image": "localnet-collection",
+        "Image": "localnet-collection:v0.0.99",
         "Names": ["flow-private-network_collection_2_1"],
         "Ports": [{}],
         "State": "running",
@@ -38,7 +38,7 @@
     {
         "CreatedAt": "2022-03-06 18:55:50 +0000 UTC",
         "ID": "3e6ce0af27fb",
-        "Image": "localnet-access",
+        "Image": "localnet-access:v0.0.99",
         "Names": ["flow-private-network_access_2_1"],
         "Ports": [{}],
         "State": "running",
@@ -47,7 +47,7 @@
     {
         "CreatedAt": "2022-03-06 18:55:50 +0000 UTC",
         "ID": "e37d90f305d9",
-        "Image": "localnet-consensus",
+        "Image": "localnet-consensus:v0.0.99",
         "Names": ["flow-private-network_consensus_1_1"],
         "Ports": [{}],
         "State": "running",
@@ -56,7 +56,7 @@
     {
         "CreatedAt": "2022-03-06 18:55:50 +0000 UTC",
         "ID": "8494996a4644",
-        "Image": "localnet-collection",
+        "Image": "localnet-collection:v0.0.99",
         "Names": ["flow-private-network_collection_1_1"],
         "Ports": [{}],
         "State": "running",
@@ -65,7 +65,7 @@
     {
         "CreatedAt": "2022-03-06 18:55:50 +0000 UTC",
         "ID": "916b1e10077e",
-        "Image": "localnet-execution",
+        "Image": "localnet-execution:v0.0.99",
         "Names": ["flow-private-network_execution_2_1"],
         "Ports": [{}],
         "State": "running",
@@ -74,7 +74,7 @@
     {
         "CreatedAt": "2022-03-06 18:55:48 +0000 UTC",
         "ID": "3cf9c1763295",
-        "Image": "localnet-access",
+        "Image": "localnet-access:v0.0.99",
         "Names": ["flow-private-network_access_1_1"],
         "Ports": [{}],
         "State": "running",
@@ -83,7 +83,7 @@
     {
         "CreatedAt": "2022-03-06 18:55:48 +0000 UTC",
         "ID": "4aaf0f504bc3",
-        "Image": "localnet-execution",
+        "Image": "localnet-execution:v0.0.99",
         "Names": ["flow-private-network_execution_1_1"],
         "Ports": [{}],
         "State": "running",
@@ -92,7 +92,7 @@
     {
         "CreatedAt": "2022-03-06 18:55:48 +0000 UTC",
         "ID": "d38ecf57e352",
-        "Image": "localnet-verification",
+        "Image": "localnet-verification:v0.0.99",
         "Names": ["flow-private-network_verification_1_1"],
         "Ports": [{}],
         "State": "running",

--- a/flow/testdata/metrics-no-version.txt
+++ b/flow/testdata/metrics-no-version.txt
@@ -1,0 +1,9 @@
+# HELP general_node_info report general information about node, such information can include version, sporkID, commit hash, etc
+# TYPE general_node_info gauge
+general_node_info{key="commit",value="4a4ee2bc3bb5addf9f02e586d75886fbe0cd26e7"} 0
+general_node_info{key="protocol_version",value="29"} 0
+general_node_info{key="spork_id",value="b2f5f7f376b3da24439c431d40f123e3124086909948926710cb9d99989835ca"} 0
+# HELP network_libp2p_resource_manager_allow_stream_total total number of streams allowed by the libp2p resource manager
+# TYPE network_libp2p_resource_manager_allow_stream_total counter
+network_libp2p_resource_manager_allow_stream_total{direction="Inbound"} 3.57637561e+08
+network_libp2p_resource_manager_allow_stream_total{direction="Outbound"} 3.69937711e+08

--- a/flow/testdata/metrics.txt
+++ b/flow/testdata/metrics.txt
@@ -1,0 +1,10 @@
+# HELP general_node_info report general information about node, such information can include version, sporkID, commit hash, etc
+# TYPE general_node_info gauge
+general_node_info{key="commit",value="4a4ee2bc3bb5addf9f02e586d75886fbe0cd26e7"} 0
+general_node_info{key="protocol_version",value="29"} 0
+general_node_info{key="spork_id",value="b2f5f7f376b3da24439c431d40f123e3124086909948926710cb9d99989835ca"} 0
+general_node_info{key="version",value="v0.29.17"} 0
+# HELP network_libp2p_resource_manager_allow_stream_total total number of streams allowed by the libp2p resource manager
+# TYPE network_libp2p_resource_manager_allow_stream_total counter
+network_libp2p_resource_manager_allow_stream_total{direction="Inbound"} 3.57637561e+08
+network_libp2p_resource_manager_allow_stream_total{direction="Outbound"} 3.69937711e+08

--- a/internal/pkg/discover/utils/utils.go
+++ b/internal/pkg/discover/utils/utils.go
@@ -17,7 +17,9 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"regexp"
@@ -280,4 +282,34 @@ func KnownNetwork(s string) bool {
 	}
 
 	return false
+}
+
+// ExtractStringFromPEFEndpoint hits the given url extracts applies the regex
+// to extract possible matches.
+func ExtractStringFromPEFEndpoint(url string, re *regexp.Regexp) ([]string, error) {
+	r, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("got response code: %v", r.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if body == nil {
+		return nil, fmt.Errorf("nil body")
+	}
+
+	if len(body) == 0 {
+		return nil, fmt.Errorf("empty body")
+	}
+
+	matches := re.FindStringSubmatch(string(body))
+
+	return matches, nil
 }


### PR DESCRIPTION
Fixes a bug where agent would skip node version configuration when network and node role was previously set during node discovery. This implements a util function used to extract the node version from a PEF endpoint using a regex. The latter is used as a default, but if the regex doesn't match, the version is extracted from the container's image tag for backwards compatibility. ReconfigurationByDocker/Systemd() are now ignoring network and node role presence and will always run a full configuration when called.